### PR TITLE
Implemented i18n !

### DIFF
--- a/commands/config.go
+++ b/commands/config.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+var translationsConfigs []*viper.Viper
+
+func init() {
+	translationsConfigs = make([]*viper.Viper, 0)
+}
+
+// readInMultilingualConfig reads the configuration, and loads any translations
+// sub-documents in the main config file.
+func readInMultilingualConfig(cfgFile, source string) error {
+	viperSetConfigFile(cfgFile, source)
+
+	// TODO: ignore error in ReadInConfig, simply use that for
+	// discovery of the file.  Then split the config file in chunks,
+	// identify the chunks and feed to ReadConfig().  This could be
+	// replaced if `viper` exposed the File without reading it.
+	_ = viper.ReadInConfig()
+	filename := viper.ConfigFileUsed()
+	cnt, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	// Initial support for YAML only:
+	for i, configDocument := range strings.Split(string(cnt), "\n---") {
+		if len(strings.TrimSpace(string(configDocument))) == 0 {
+			continue
+		}
+		viper.SetDefaultConfig(viper.New())
+
+		viperSetConfigFile(cfgFile, source)
+
+		err := viper.ReadConfig(bytes.NewBuffer([]byte(configDocument)))
+		if err != nil {
+			return fmt.Errorf("in config document %d: %s", i+1, err)
+		}
+
+		viper.RegisterAlias("indexes", "taxonomies")
+
+		LoadDefaultSettings()
+
+		translationsConfigs = append(translationsConfigs, viper.DefaultConfig())
+	}
+
+	if len(translationsConfigs) == 0 {
+		return fmt.Errorf("found 0 config blocks in %q", filename)
+	}
+
+	viper.SetDefaultConfig(translationsConfigs[0])
+
+	return nil
+}
+
+func viperSetConfigFile(cfgFile, source string) {
+	viper.SetConfigFile(CfgFile)
+	// See https://github.com/spf13/viper/issues/73#issuecomment-126970794
+	if Source == "" {
+		viper.AddConfigPath(".")
+	} else {
+		viper.AddConfigPath(Source)
+	}
+}
+
+// viperSetAll calls `viper.Set` on the all translations' configs.
+func viperSetAll(key string, value interface{}) {
+	viper.Set(key, value)
+	for _, conf := range translationsConfigs {
+		conf.Set(key, value)
+	}
+}
+
+// viperSetDefaultAll calls `viper.SetDefault` on all translations'
+// configs.
+func viperSetDefaultAll(key string, value interface{}) {
+	viper.SetDefault(key, value)
+	for _, conf := range translationsConfigs {
+		conf.SetDefault(key, value)
+	}
+}

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -212,6 +212,7 @@ func LoadDefaultSettings() {
 	viper.SetDefault("ArchetypeDir", "archetypes")
 	viper.SetDefault("PublishDir", "public")
 	viper.SetDefault("DataDir", "data")
+	viper.SetDefault("I18nDir", "i18n")
 	viper.SetDefault("ThemesDir", "themes")
 	viper.SetDefault("DefaultLayout", "post")
 	viper.SetDefault("BuildDrafts", false)
@@ -246,6 +247,7 @@ func LoadDefaultSettings() {
 	viper.SetDefault("HasCJKLanguage", false)
 	viper.SetDefault("Multilingual", false)
 	viper.SetDefault("DefaultContentLang", "en")
+	viper.SetDefault("RenderLanguage", "en")
 }
 
 // InitializeConfig initializes a config file with sensible default configuration flags.
@@ -463,19 +465,25 @@ func copyStatic() error {
 func getDirList() []string {
 	var a []string
 	dataDir := helpers.AbsPathify(viper.GetString("DataDir"))
+	i18nDir := helpers.AbsPathify(viper.GetString("I18nDir"))
 	layoutDir := helpers.AbsPathify(viper.GetString("LayoutDir"))
 	walker := func(path string, fi os.FileInfo, err error) error {
 		if err != nil {
 			if path == dataDir && os.IsNotExist(err) {
 				jww.WARN.Println("Skip DataDir:", err)
 				return nil
-
 			}
+
+			if path == i18nDir && os.IsNotExist(err) {
+				jww.WARN.Println("Skip I18nDir:", err)
+				return nil
+			}
+
 			if path == layoutDir && os.IsNotExist(err) {
 				jww.WARN.Println("Skip LayoutDir:", err)
 				return nil
-
 			}
+
 			jww.ERROR.Println("Walker: ", err)
 			return nil
 		}
@@ -508,6 +516,7 @@ func getDirList() []string {
 	}
 
 	filepath.Walk(dataDir, walker)
+	filepath.Walk(i18nDir, walker)
 	filepath.Walk(helpers.AbsPathify(viper.GetString("ContentDir")), walker)
 	filepath.Walk(helpers.AbsPathify(viper.GetString("LayoutDir")), walker)
 	filepath.Walk(helpers.AbsPathify(viper.GetString("StaticDir")), walker)

--- a/commands/hugo.go
+++ b/commands/hugo.go
@@ -244,6 +244,8 @@ func LoadDefaultSettings() {
 	viper.SetDefault("SectionPagesMenu", "")
 	viper.SetDefault("DisablePathToLower", false)
 	viper.SetDefault("HasCJKLanguage", false)
+	viper.SetDefault("Multilingual", false)
+	viper.SetDefault("DefaultContentLang", "en")
 }
 
 // InitializeConfig initializes a config file with sensible default configuration flags.

--- a/docs/content/content/multilingual.md
+++ b/docs/content/content/multilingual.md
@@ -1,0 +1,113 @@
+---
+date: 2016-01-02T21:21:00Z
+menu:
+  main:
+    parent: content
+next: /content/example
+prev: /content/summaries
+title: Multilingual Mode
+weight: 68
+toc: true
+---
+
+Since version 0.16, Hugo supports a native Multilingual mode. You can enable it with:
+
+```
+Multilingual: true
+RenderLanguage: en
+```
+
+in your site configuration.
+
+With the config above, all content, sitemap, RSS feeds, paginations
+and taxonomy pages will be rendered under `/en`.
+
+You will also need two config files (`config.en.yaml` and
+`config.fr.yaml` for example) and you will need to run `hugo` twice,
+to render each language's HTML.
+
+
+### Translating your content
+
+Translated articles are picked up by the name of the content files.
+
+Example of translated articles:
+
+1. `/content/about.en.md`
+2. `/content/about.fr.md`
+
+You can also have:
+
+1. `/content/about.md`
+2. `/content/about.fr.md`
+
+in which case the config variable `DefaultContentLang` will be used to
+affect the default language `about.md`.  This way, you can slowly
+start to translate your current content without having to rename
+everything.
+
+If left unspecified, the value for `DefaultContentLang` defaults to
+`en`.
+
+By having the same _base file name_, the content pieces are linked
+together as translated pieces. Only the content pieces in the language
+defined by **.Site.RenderLanguage** will be rendered in a run of
+`hugo`.  The translated content will be available in the
+`.Page.Translations` so you can create links to the corresponding
+translated pieces.
+
+
+### Language switching links
+
+A full example of the language-switching links would be:
+
+```
+{{if .Site.Multilingual}}
+  {{if .IsPage}}
+    {{ range $txLang := .Site.LinkLanguages }}
+      {{if ne $lang $txLang}}
+        {{if isset $.Translations $txLang}}
+          <a href="{{ (index $.Translations $txLang).Permalink }}">{{ index $.Site.Data.i18n "langlinks" $txLang }}</a>
+        {{else}}
+          <a href="/{{$txLang}}">{{ index $.Site.Data.i18n "langlinks" $txLang }}</a>
+        {{end}}
+      {{end}}
+    {{end}}
+  {{end}}
+
+  {{if .IsNode}}
+    {{ range $txLang := .Site.LinkLanguages }}
+      {{if ne $lang $txLang}}
+        <a href="/{{$txLang}}">{{ index $.Site.Data.i18n "langlinks" $txLang }}</a>
+      {{end}}
+    {{end}}
+  {{end}}
+{{end}}
+```
+
+This makes use of the **.Site.LinkLanguages** variable to always
+create links to the other available languages. You would define this
+in your config as:
+
+```
+LinkLanguages:
+ - fr
+ - en
+```
+
+As you might notice, node pages link to the root of the other
+available translations (`/en`), as those pages do not necessarily have
+a translated counterpart.
+
+Taxonomies (tags, categories) are completely segregated between
+translations, will have their own tag clouds and list views.
+
+
+### Multilingual Themes support
+
+To support Multilingual mode in your themes, you only need to make
+sure URLs defined manually (those not using `.Permalink` or `.URL`
+variables) in your templates are prefixed with `{{
+.Site.LanguagePrefix }}`. If `Multilingual` mode is enabled, this will
+be rendered as `/en` (based on `RenderLanguage`). If not enabled, it
+will be an empty string, so it is harmless for non-multilingual sites.

--- a/docs/content/taxonomies/displaying.md
+++ b/docs/content/taxonomies/displaying.md
@@ -38,7 +38,7 @@ each content piece are located in the usual place
 
     <ul id="tags">
       {{ range .Params.tags }}
-        <li><a href="tags/{{ . | urlize }}">{{ . }}</a> </li>
+        <li><a href="{{.Site.LanguagePrefix}}/tags/{{ . | urlize }}">{{ . }}</a> </li>
       {{ end }}
     </ul>
 
@@ -93,7 +93,7 @@ The following example displays all tag keys:
 
     <ul id="all-tags">
       {{ range $name, $taxonomy := .Site.Taxonomies.tags }}
-        <li><a href="/tags/{{ $name | urlize }}">{{ $name }}</a></li>
+        <li><a href="{{.Site.LanguagePrefix}}/tags/{{ $name | urlize }}">{{ $name }}</a></li>
       {{ end }}
     </ul>
 
@@ -103,7 +103,7 @@ This example will list all taxonomies, each of their keys and all the content as
     <section>
       <ul>
         {{ range $taxonomyname, $taxonomy := .Site.Taxonomies }}
-          <li><a href="/{{ $taxonomyname | urlize }}">{{ $taxonomyname }}</a>
+          <li><a href="{{.Site.LanguagePrefix}}/{{ $taxonomyname | urlize }}">{{ $taxonomyname }}</a>
             <ul>
               {{ range $key, $value := $taxonomy }}
               <li> {{ $key }} </li>
@@ -118,4 +118,3 @@ This example will list all taxonomies, each of their keys and all the content as
         {{ end }}
       </ul>
     </section>
-

--- a/docs/content/taxonomies/ordering.md
+++ b/docs/content/taxonomies/ordering.md
@@ -29,7 +29,7 @@ Taxonomies can be ordered by either alphabetical key or by the number of content
     <ul>
     {{ $data := .Data }}
     {{ range $key, $value := .Data.Taxonomy.Alphabetical }}
-    <li><a href="{{ $data.Plural }}/{{ $value.Name | urlize }}"> {{ $value.Name }} </a> {{ $value.Count }} </li>
+    <li><a href="{{ .Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}"> {{ $value.Name }} </a> {{ $value.Count }} </li>
     {{ end }}
     </ul>
 
@@ -38,7 +38,7 @@ Taxonomies can be ordered by either alphabetical key or by the number of content
     <ul>
     {{ $data := .Data }}
     {{ range $key, $value := .Data.Taxonomy.ByCount }}
-    <li><a href="{{ $data.Plural }}/{{ $value.Name | urlize }}"> {{ $value.Name }} </a> {{ $value.Count }} </li>
+    <li><a href="{{ .Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}"> {{ $value.Name }} </a> {{ $value.Count }} </li>
     {{ end }}
     </ul>
 

--- a/docs/content/templates/terms.md
+++ b/docs/content/templates/terms.md
@@ -89,7 +89,7 @@ content tagged with each tag.
         <ul>
         {{ $data := .Data }}
         {{ range $key, $value := .Data.Terms }}
-          <li><a href="{{ $data.Plural }}/{{ $key | urlize }}">{{ $key }}</a> {{ len $value }}</li>
+          <li><a href="{{ .Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $key | urlize }}">{{ $key }}</a> {{ len $value }}</li>
         {{ end }}
        </ul>
       </div>
@@ -109,7 +109,7 @@ Another example listing the content for each term (ordered by Date):
 
         {{ $data := .Data }}
         {{ range $key,$value := .Data.Terms.ByCount }}
-        <h2><a href="{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a> {{ $value.Count }}</h2>
+        <h2><a href="{{ .Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a> {{ $value.Count }}</h2>
         <ul>
         {{ range $value.Pages.ByDate }}
           <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
@@ -140,7 +140,7 @@ Hugo can order the meta data in two different ways. It can be ordered:
         <ul>
         {{ $data := .Data }}
         {{ range $key, $value := .Data.Terms.Alphabetical }}
-          <li><a href="{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a> {{ $value.Count }}</li>
+          <li><a href="{{ .Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a> {{ $value.Count }}</li>
         {{ end }}
         </ul>
       </div>
@@ -158,7 +158,7 @@ Hugo can order the meta data in two different ways. It can be ordered:
         <ul>
         {{ $data := .Data }}
         {{ range $key, $value := .Data.Terms.ByCount }}
-          <li><a href="{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a> {{ $value.Count }}</li>
+          <li><a href="{{ .Site.LanguagePrefix }}/{{ $data.Plural }}/{{ $value.Name | urlize }}">{{ $value.Name }}</a> {{ $value.Count }}</li>
         {{ end }}
         </ul>
       </div>

--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -150,7 +150,7 @@ Also available is `.Site` which has the following:
 **.Site.BuildDrafts** A boolean (Default: false) to indicate whether to build drafts. Defined in the site configuration.<br>
 **.Site.Data**  Custom data, see [Data Files](/extras/datafiles/).<br>
 **.Site.Multilingual** Whether the site supports internationalization of the content. With this mode enabled, all your posts' URLs will be prefixed with the language (ex: `/en/2016/01/01/my-post`)<br>
-**.Site.RenderLanguage** When using `Multilingual` mode, will render the site in this language. You can then run `hugo` again with a second `config` file, with the other languages.<br>
+**.Site.RenderLanguage** This indicates which language you are currently rendering the website for.  When using `Multilingual` mode, will render the site in this language. You can then run `hugo` again with a second `config` file, with the other languages. When using `i18n` and `T` template functions, it will use the `i18n/*.yaml` files (in either `/themes/[yourtheme]/i18n` or the `/i18n`, translations in the latter having precedence).<br>
 **.Site.LanguagePrefix** When `Multilingual` is enabled, this will hold `/{{ .Site.RenderLanguage}}`, otherwise will be an empty string.  Using this to prefix taxonomies or other hard-coded links ensures your keep your theme compatible with Multilingual configurations.
 **.Site.LinkLanguages** A list of languages. Used in your templates to iterate through and create links to different languages.<br>
 **.Site.DefaultContentLang** When `Multilingual` is `true`, this would

--- a/docs/content/templates/variables.md
+++ b/docs/content/templates/variables.md
@@ -56,6 +56,8 @@ matter, content or derived from file location.
 **.IsPage** Always true for page.<br>
 **.Site** See [Site Variables]({{< relref "#site-variables" >}}) below.<br>
 **.Hugo** See [Hugo Variables]({{< relref "#hugo-variables" >}}) below.<br>
+**.Translations** A map to other pages with the same filename, but with a different language-extension (like `post.fr.md`).  Populated only if `Multilingual` is enabled in your site config.
+**.Lang** Taken from the language extension notation.  Populated only if `Multilingual` is enabled for your site config.
 
 ## Page Params
 
@@ -96,9 +98,9 @@ includes taxonomies, lists and the homepage.
 **.Site** See [Site Variables]({{< relref "#site-variables" >}}) below.<br>
 **.Hugo** See [Hugo Variables]({{< relref "#hugo-variables" >}}) below.<br>
 
-### Taxonomy Term Variables
+### Taxonomy Terms Node Variables
 
-[Taxonomy Terms](/templates/terms/) pages are of the type "node" and have the following additional variables.
+[Taxonomy Terms](/templates/terms/) pages are of the type "node" and have the following additional variables. These are available in `layouts/_defaults/terms.html` for example.
 
 **.Data.Singular** The singular name of the taxonomy<br>
 **.Data.Plural** The plural name of the taxonomy<br>
@@ -109,13 +111,23 @@ includes taxonomies, lists and the homepage.
 
 The last two can also be reversed: **.Data.Terms.Alphabetical.Reverse**, **.Data.Terms.ByCount.Reverse**.
 
+### Taxonomies elsewhere
+
+The **.Site.Taxonomies** variable holds all taxonomies defines site-wide.  It is a map of the taxonomy name to a list of its values. For example: "tags" -> ["tag1", "tag2", "tag3"]. Each value, though, is not a string but rather a [Taxonomy variable](#the-taxonomy-variable).
+
+#### The Taxonomy variable
+
+The Taxonomy variable, available as **.Site.Taxonomies.tags** for example, contains the list of tags (values) and, for each of those, their corresponding content pages.
+
+
+
 ## Site Variables
 
 Also available is `.Site` which has the following:
 
 **.Site.BaseURL** The base URL for the site as defined in the site configuration file.<br>
 **.Site.RSSLink** The URL for the site RSS.<br>
-**.Site.Taxonomies** The [taxonomies](/taxonomies/usage/) for the entire site.  Replaces the now-obsolete `.Site.Indexes` since v0.11.<br>
+**.Site.Taxonomies** The [taxonomies](/taxonomies/usage/) for the entire site.  Replaces the now-obsolete `.Site.Indexes` since v0.11. Also see section [Taxonomies elsewhere](#taxonomies-elsewhere).
 **.Site.Pages** Array of all content ordered by Date, newest first.  Replaces the now-deprecated `.Site.Recent` starting v0.13.<br>
 **.Site.Params** A container holding the values from the `params` section of your site configuration file. For example, a TOML config file might look like this:
 
@@ -129,7 +141,7 @@ Also available is `.Site` which has the following:
 **.Site.Menus** All of the menus in the site.<br>
 **.Site.Title** A string representing the title of the site.<br>
 **.Site.Author** A map of the authors as defined in the site configuration.<br>
-**.Site.LanguageCode** A string representing the language as defined in the site configuration.<br>
+**.Site.LanguageCode** A string representing the language as defined in the site configuration. This is mostly used to populate the RSS feeds with the right language code.<br>
 **.Site.DisqusShortname** A string representing the shortname of the Disqus shortcode as defined in the site configuration.<br>
 **.Site.GoogleAnalytics** A string representing your tracking code for Google Analytics as defined in the site configuration.<br>
 **.Site.Copyright** A string representing the copyright of your web site as defined in the site configuration.<br>
@@ -137,6 +149,15 @@ Also available is `.Site` which has the following:
 **.Site.Permalinks** A string to override the default permalink format. Defined in the site configuration.<br>
 **.Site.BuildDrafts** A boolean (Default: false) to indicate whether to build drafts. Defined in the site configuration.<br>
 **.Site.Data**  Custom data, see [Data Files](/extras/datafiles/).<br>
+**.Site.Multilingual** Whether the site supports internationalization of the content. With this mode enabled, all your posts' URLs will be prefixed with the language (ex: `/en/2016/01/01/my-post`)<br>
+**.Site.RenderLanguage** When using `Multilingual` mode, will render the site in this language. You can then run `hugo` again with a second `config` file, with the other languages.<br>
+**.Site.LanguagePrefix** When `Multilingual` is enabled, this will hold `/{{ .Site.RenderLanguage}}`, otherwise will be an empty string.  Using this to prefix taxonomies or other hard-coded links ensures your keep your theme compatible with Multilingual configurations.
+**.Site.LinkLanguages** A list of languages. Used in your templates to iterate through and create links to different languages.<br>
+**.Site.DefaultContentLang** When `Multilingual` is `true`, this would
+  be the default language for files without language-extensions (like
+  `post.md` vs the spanish translation `post.es.md`). It defaults to
+  `en`. You shouldn't need to worry about this if all your content has
+  a language extension like `post.es.md`.<br>
 
 ## Hugo Variables
 

--- a/helpers/path.go
+++ b/helpers/path.go
@@ -153,10 +153,16 @@ func GetThemeStaticDirPath() (string, error) {
 	return getThemeDirPath("static")
 }
 
-// GetThemeStaticDirPath returns the theme's data dir path if theme is set.
+// GetThemeDataDirPath returns the theme's data dir path if theme is set.
 // If theme is set and the data dir doesn't exist, an error is returned.
 func GetThemeDataDirPath() (string, error) {
 	return getThemeDirPath("data")
+}
+
+// GetThemeI18nDirPath returns the theme's i18n dir path if theme is set.
+// If theme is set and the i18n dir doesn't exist, an error is returned.
+func GetThemeI18nDirPath() (string, error) {
+	return getThemeDirPath("i18n")
 }
 
 func getThemeDirPath(path string) (string, error) {

--- a/hugolib/i18n.go
+++ b/hugolib/i18n.go
@@ -1,0 +1,37 @@
+// Copyright 2016 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hugolib
+
+import (
+	"github.com/nicksnyder/go-i18n/i18n/bundle"
+	"github.com/spf13/hugo/source"
+	"github.com/spf13/hugo/tpl"
+	"github.com/spf13/viper"
+)
+
+func loadI18n(sources []source.Input) (err error) {
+	i18nBundle := bundle.New()
+	for _, currentSource := range sources {
+		for _, r := range currentSource.Files() {
+			err = i18nBundle.ParseTranslationFileBytes(r.LogicalName(), r.Bytes())
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	tpl.SetI18nTfunc(viper.GetString("RenderLanguage"), i18nBundle)
+
+	return nil
+}

--- a/hugolib/permalinks.go
+++ b/hugolib/permalinks.go
@@ -159,7 +159,7 @@ func pageToPermalinkTitle(p *Page, _ string) (string, error) {
 func pageToPermalinkFilename(p *Page, _ string) (string, error) {
 	//var extension = p.Source.Ext
 	//var name = p.Source.Path()[0 : len(p.Source.Path())-len(extension)]
-	return helpers.URLize(p.Source.BaseFileName()), nil
+	return helpers.URLize(p.Source.TranslationBaseName()), nil
 }
 
 // if the page has a slug, return the slug, else return the title

--- a/hugolib/site.go
+++ b/hugolib/site.go
@@ -527,19 +527,30 @@ func (s *Site) Process() (err error) {
 	s.timerStep("initialize & template prep")
 
 	dataSources := make([]source.Input, 0, 2)
-
 	dataSources = append(dataSources, &source.Filesystem{Base: s.absDataDir()})
 
 	// have to be last - duplicate keys in earlier entries will win
-	themeStaticDir, err := helpers.GetThemeDataDirPath()
+	themeDataDir, err := helpers.GetThemeDataDirPath()
 	if err == nil {
-		dataSources = append(dataSources, &source.Filesystem{Base: themeStaticDir})
+		dataSources = append(dataSources, &source.Filesystem{Base: themeDataDir})
 	}
 
 	if err = s.loadData(dataSources); err != nil {
 		return
 	}
 	s.timerStep("load data")
+
+	i18nSources := []source.Input{&source.Filesystem{Base: s.absI18nDir()}}
+
+	themeI18nDir, err := helpers.GetThemeI18nDirPath()
+	if err == nil {
+		i18nSources = []source.Input{&source.Filesystem{Base: themeI18nDir}, i18nSources[0]}
+	}
+
+	if err = loadI18n(i18nSources); err != nil {
+		return
+	}
+	s.timerStep("load i18n")
 
 	if err = s.CreatePages(); err != nil {
 		return
@@ -703,6 +714,10 @@ func (s *Site) hasTheme() bool {
 
 func (s *Site) absDataDir() string {
 	return helpers.AbsPathify(viper.GetString("DataDir"))
+}
+
+func (s *Site) absI18nDir() string {
+	return helpers.AbsPathify(viper.GetString("I18nDir"))
 }
 
 func (s *Site) absThemeDir() string {

--- a/hugolib/site_test.go
+++ b/hugolib/site_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -339,7 +340,7 @@ func doTestCrossrefs(t *testing.T, relative, uglyURLs bool) {
 			[]byte(fmt.Sprintf(`Ref 2: {{< %s "sect/doc2.md" >}}`, refShortcode))},
 		// Issue #1148: Make sure that no P-tags is added around shortcodes.
 		{filepath.FromSlash("sect/doc2.md"),
-			[]byte(fmt.Sprintf(`**Ref 1:** 
+			[]byte(fmt.Sprintf(`**Ref 1:**
 
 {{< %s "sect/doc1.md" >}}
 
@@ -1282,5 +1283,166 @@ func TestGitHubFileLinking(t *testing.T) {
 	// TODO: and then the failure cases.
 	// 			"https://docker.com":           "",
 	// site_test.go:1094: Expected https://docker.com to resolve to (), got () - error: Not a plain filepath link (https://docker.com)
+}
 
+func TestMultilingualSwitch(t *testing.T) {
+	// General settings
+	viper.Set("DefaultExtension", "html")
+	viper.Set("baseurl", "http://example.com/blog")
+	viper.Set("DisableSitemap", false)
+	viper.Set("DisableRSS", false)
+	viper.Set("RSSUri", "index.xml")
+	viper.Set("Taxonomies", map[string]string{"tag": "tags"})
+	viper.Set("Permalinks", map[string]string{"other": "/somewhere/else/:filename"})
+
+	// Multilingual settings
+	viper.Set("Multilingual", true)
+	viper.Set("RenderLanguage", "en")
+	viper.Set("DefaultContentLang", "fr")
+	viper.Set("paginate", "2")
+
+	// Sources
+	sources := []source.ByteSource{
+		{filepath.FromSlash("sect/doc1.en.md"), []byte(`---
+title: doc1
+slug: doc1-slug
+tags:
+ - tag1
+publishdate: "2000-01-01"
+---
+# doc1
+*some content*
+NOTE: slug should be used as URL
+`)},
+		{filepath.FromSlash("sect/doc1.fr.md"), []byte(`---
+title: doc1
+tags:
+ - tag1
+ - tag2
+publishdate: "2000-01-04"
+---
+# doc1
+*quelque contenu*
+NOTE: should be in the 'en' Page's 'Translations' field.
+NOTE: date is after "doc3"
+`)},
+		{filepath.FromSlash("sect/doc2.en.md"), []byte(`---
+title: doc2
+publishdate: "2000-01-02"
+---
+# doc2
+*some content*
+NOTE: without slug, "doc2" should be used, without ".en" as URL
+`)},
+		{filepath.FromSlash("sect/doc3.en.md"), []byte(`---
+title: doc3
+publishdate: "2000-01-03"
+tags:
+ - tag2
+url: /superbob
+---
+# doc3
+*some content*
+NOTE: third 'en' doc, should trigger pagination on home page.
+`)},
+		{filepath.FromSlash("sect/doc4.md"), []byte(`---
+title: doc4
+tags:
+ - tag1
+publishdate: "2000-01-05"
+---
+# doc4
+*du contenu francophone*
+NOTE: should use the DefaultContentLang and mark this doc as 'fr'.
+NOTE: doesn't have any corresponding translation in 'en'
+`)},
+		{filepath.FromSlash("other/doc5.fr.md"), []byte(`---
+title: doc5
+publishdate: "2000-01-06"
+---
+# doc5
+*autre contenu francophone*
+NOTE: should use the "permalinks" configuration with :filename
+`)},
+	}
+
+	hugofs.DestinationFS = new(afero.MemMapFs)
+
+	s := &Site{
+		Source: &source.InMemorySource{ByteSource: sources},
+	}
+	templatePrep(s)
+	s.initializeSiteInfo()
+
+	if err := s.CreatePages(); err != nil {
+		t.Fatalf("Unable to create pages: %s", err)
+	}
+
+	s.setupTranslations()
+	s.setupPrevNext()
+
+	if err := s.BuildSiteMeta(); err != nil {
+		t.Fatalf("Unable to build site metadata: %s", err)
+	}
+
+	assert.Len(t, s.Source.Files(), 6, "should have 6 source files")
+	assert.Len(t, s.Pages, 3, "should have 3 pages")
+	assert.Len(t, s.TranslatedPages, 3, "should have 3 translated pages")
+
+	doc1en := s.Pages[0]
+	permalink, err := doc1en.Permalink()
+	assert.NoError(t, err, "permalink call failed")
+	assert.Equal(t, "http://example.com/blog/en/sect/doc1-slug", permalink, "invalid doc1.en permalink")
+
+	assert.Len(t, doc1en.Translations, 1, "doc1-en should have one translation")
+
+	doc2 := s.Pages[1]
+	permalink, err = doc2.Permalink()
+	assert.NoError(t, err, "permalink call failed")
+	assert.Equal(t, "http://example.com/blog/en/sect/doc2", permalink, "invalid doc2 permalink")
+
+	doc3 := s.Pages[2]
+	permalink, err = doc3.Permalink()
+	assert.NoError(t, err, "permalink call failed")
+	assert.Equal(t, "http://example.com/blog/superbob", permalink, "invalid doc3 permalink")
+	assert.Equal(t, "/superbob", doc3.URL, "invalid url, was specified on doc3")
+
+	assert.Equal(t, doc2.Next, doc3, "doc3 should follow doc2, in .Next")
+
+	doc1fr := s.TranslatedPages[0]
+	permalink, err = doc1fr.Permalink()
+	assert.NoError(t, err, "permalink call failed")
+	assert.Equal(t, "http://example.com/blog/fr/sect/doc1", permalink, "invalid doc1fr permalink")
+
+	assert.Equal(t, doc1en.Translations["fr"], doc1fr, "doc1-en should have doc1-fr as translation")
+	assert.Equal(t, doc1fr.Translations["en"], doc1en, "doc1-fr should have doc1-en as translation")
+
+	doc4 := s.TranslatedPages[1]
+	permalink, err = doc4.Permalink()
+	assert.NoError(t, err, "permalink call failed")
+	assert.Equal(t, "http://example.com/blog/fr/sect/doc4", permalink, "invalid doc4 permalink")
+	assert.Len(t, doc4.Translations, 0, "found translations for doc4")
+
+	doc5 := s.TranslatedPages[2]
+	permalink, err = doc5.Permalink()
+	assert.NoError(t, err, "permalink call failed")
+	assert.Equal(t, "http://example.com/blog/fr/somewhere/else/doc5", permalink, "invalid doc5 permalink")
+
+	// Taxonomies and their URLs
+	assert.Len(t, s.Taxonomies, 1, "should have 1 taxonomy")
+	tags := s.Taxonomies["tags"]
+	assert.Len(t, tags, 2, "should have 2 different tags")
+	assert.Equal(t, tags["tag1"][0].Page, doc1en, "first tag1 page should be doc1")
+
+	// Expect the tags locations to be in certain places, with the /en/ prefixes, etc..
+}
+
+func assertFileContent(t *testing.T, path string, content string) {
+	fl, err := hugofs.DestinationFS.Open(path)
+	assert.NoError(t, err, "file content not found when asserting on content of %s", path)
+
+	cnt, err := ioutil.ReadAll(fl)
+	assert.NoError(t, err, "cannot read file content when asserting on content of %s", path)
+
+	assert.Equal(t, content, string(cnt))
 }

--- a/hugolib/translations.go
+++ b/hugolib/translations.go
@@ -1,0 +1,59 @@
+// Copyright 2015 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hugolib
+
+// Translations represent the other translations for a given page. The
+// string here is the language code, as affected by the `post.LANG.md`
+// filename.
+type Translations map[string]*Page
+
+func pagesToTranslationsMap(pages []*Page) map[string]Translations {
+	out := make(map[string]Translations)
+
+	for _, page := range pages {
+		base := page.TranslationBaseName()
+
+		pageTranslation, present := out[base]
+		if !present {
+			pageTranslation = make(Translations)
+		}
+
+		pageLang := page.Lang()
+		if pageLang == "" {
+			continue
+		}
+
+		pageTranslation[pageLang] = page
+		out[base] = pageTranslation
+	}
+
+	return out
+}
+
+func assignTranslationsToPages(allTranslations map[string]Translations, pages []*Page) {
+	for _, page := range pages {
+		base := page.TranslationBaseName()
+		trans, exist := allTranslations[base]
+		if !exist {
+			continue
+		}
+
+		for lang, translatedPage := range trans {
+			if translatedPage == page {
+				continue
+			}
+			page.Translations[lang] = translatedPage
+		}
+	}
+}

--- a/source/file.go
+++ b/source/file.go
@@ -14,20 +14,26 @@
 package source
 
 import (
-	"github.com/spf13/hugo/helpers"
 	"io"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/hugo/helpers"
+	"github.com/spf13/viper"
 )
 
 type File struct {
 	relpath     string // Original Full Path eg. /Users/Home/Hugo/foo.txt
 	logicalName string // foo.txt
+	baseName    string // `post` for `post.md`, also `post.en` for `post.en.md`
 	Contents    io.Reader
 	section     string // The first directory
 	dir         string // The full directory Path (minus file name)
 	ext         string // Just the ext (eg txt)
 	uniqueID    string // MD5 of the filename
+
+	translationBaseName string // `post` for `post.es.md` (if `Multilingual` is enabled.)
+	lang                string // The language code if `Multilingual` is enabled
 }
 
 func (f *File) UniqueID() string {
@@ -44,7 +50,17 @@ func (f *File) Bytes() []byte {
 
 // Filename without extension
 func (f *File) BaseFileName() string {
-	return helpers.Filename(f.LogicalName())
+	return f.baseName
+}
+
+// Filename with no extension, not even the optional language extension part.
+func (f *File) TranslationBaseName() string {
+	return f.translationBaseName
+}
+
+// Lang for this page, if `Multilingual` is enabled on your site.
+func (f *File) Lang() string {
+	return f.lang
 }
 
 func (f *File) Section() string {
@@ -89,6 +105,17 @@ func NewFile(relpath string) *File {
 	f.dir, _ = filepath.Split(f.relpath)
 	_, f.logicalName = filepath.Split(f.relpath)
 	f.ext = strings.TrimPrefix(filepath.Ext(f.LogicalName()), ".")
+	f.baseName = helpers.Filename(f.LogicalName())
+	if viper.GetBool("Multilingual") {
+		f.lang = strings.TrimPrefix(filepath.Ext(f.baseName), ".")
+		if f.lang == "" {
+			f.lang = viper.GetString("DefaultContentLang")
+		}
+		f.translationBaseName = helpers.Filename(f.baseName)
+	} else {
+		f.translationBaseName = f.baseName
+	}
+
 	f.section = helpers.GuessSection(f.Dir())
 	f.uniqueID = helpers.Md5String(f.LogicalName())
 

--- a/tpl/template_funcs.go
+++ b/tpl/template_funcs.go
@@ -1533,5 +1533,7 @@ func init() {
 			}
 			return inflect.Singularize(word), nil
 		},
+		"i18n": I18nTranslate,
+		"T":    I18nTranslate,
 	}
 }

--- a/tpl/template_i18n.go
+++ b/tpl/template_i18n.go
@@ -1,0 +1,47 @@
+// Copyright 2015 The Hugo Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpl
+
+import (
+	"fmt"
+
+	"github.com/nicksnyder/go-i18n/i18n/bundle"
+	jww "github.com/spf13/jwalterweatherman"
+)
+
+var i18nTfunc bundle.TranslateFunc
+
+func SetI18nTfunc(lang string, bndl *bundle.Bundle) {
+	tFunc, err := bndl.Tfunc(lang)
+	if err == nil {
+		i18nTfunc = tFunc
+		return
+	}
+
+	jww.WARN.Printf("could not load translations for language %q (%s), will not translate!\n", lang, err.Error())
+	i18nTfunc = bundle.TranslateFunc(func(id string, args ...interface{}) string {
+		// TODO: depending on the site mode, we might want to fall back on the default
+		// language's translation.
+		// TODO: eventually, we could add --i18n-warnings and print something when
+		// such things happen.
+		return fmt.Sprintf("[i18n: %s]", id)
+	})
+}
+
+func I18nTranslate(id string, args ...interface{}) (string, error) {
+	if i18nTfunc == nil {
+		return "", fmt.Errorf("i18n not initialized, have you configured everything properly?")
+	}
+	return i18nTfunc(id, args...), nil
+}


### PR DESCRIPTION
Leverages the great github.com/nicksnyder/go-i18n lib.. thanks @nicksnyder !

Adds "i18n" and "T" template functions..

Does not depend on Multilingual.  Does depend on `RenderLanguage` though,
which is introduced in https://github.com/spf13/hugo/pull/1734 
could be made not to, and always default to "en".

go-i18n supports asking for "en" and then rendering "en-US" by default..
so translations can have more complete "en-GB", "en-US" yaml or json files.

Translation files can be in the theme (under `theme/your_theme/i18n/`, not `data/i18n`), and can be overridden in `/i18n` at the root of your site.

If you don't have translations for the current "RenderLanguage", it will fallback to the `id` of the string inside a marker: `[i18n: id_of_the_string]` .. so you can spot the missing translations (and search for them) quickly in the rendered site.

/cc @spf13

TODO: documentation.
